### PR TITLE
fix: qemu package name

### DIFF
--- a/dev_cycle/terraform/install.sh
+++ b/dev_cycle/terraform/install.sh
@@ -21,7 +21,7 @@ add-apt-repository \
    stable"
 apt-get update
 apt-get remove docker docker-engine docker.io containerd runc
-apt-get -y install docker-ce docker-ce-cli containerd.io qemu
+apt-get -y install docker-ce docker-ce-cli containerd.io qemu-kvm
 usermod -a -G docker ubuntu
 
 # install linuxkit


### PR DESCRIPTION
I couldn't make it work with `qemu` (https://github.com/vouch-opensource/linuxkit-image-development/issues/5) so I'm changing to `qemu-kvm`. I'm not sure the difference between `qemu` and `qemu-kvm` since kvm is already enabled by default in qemu builds. Versions in both are pretty the same.