### PR TITLE
feat: allow build machine to push images to S3

### DIFF
--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -7,6 +7,7 @@ variable "machine_name" {}
 variable "vpc_id" {}
 variable "aws_iam_role_id" {}
 variable "ebs_kms_key_arn" {}
+variable "linuxkit_s3_bucket" {}
 
 variable "install" {
   type = object({

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -104,6 +104,29 @@ data "aws_iam_policy_document" "build_machine" {
     resources = ["*"]
   }
 
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListMultipartUploadParts"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.linuxkit_s3_bucket}"
+    ]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetObject*",
+      "s3:PutObject*"
+    ]
+    resources = [
+      "arn:aws:s3:::${var.linuxkit_s3_bucket}/*"
+    ]
+  }
+
   depends_on = [data.aws_instance.linuxkit_instance]
 }
 


### PR DESCRIPTION
IMHO build machine should be allowed to push linuxkit images to S3 instead copy aws credentials into the machine or even build it locally