### PR TITLE
fix: missing iam permissions to create AMI

### DIFF
--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -127,6 +127,18 @@ data "aws_iam_policy_document" "build_machine" {
     ]
   }
 
+  statement {
+    effect = "Allow"
+    actions = [
+      "ec2:ImportSnapshot",
+      "ec2:DescribeImportSnapshotTasks",
+      "ec2:RegisterImage"
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
   depends_on = [data.aws_instance.linuxkit_instance]
 }
 


### PR DESCRIPTION
add a bunch of EC2 permissions in order to allow build machine to create AMI

This PR is an fix/addition to https://github.com/vouch-opensource/linuxkit-image-development/pull/8