### PR TITLE
feat: ec2 spot support

### DIFF
--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -19,3 +19,7 @@ variable "install" {
     babashka_version = "master"
   }
 }
+
+variable "instance_ondemand" {
+  default = true
+}

--- a/dev_cycle/terraform/install.sh
+++ b/dev_cycle/terraform/install.sh
@@ -2,6 +2,21 @@
 
 set -ex
 
+# ephemeral disk setup
+
+apt install nvme-cli
+
+ephemeral_disk=$(nvme list | grep "Instance Storage" | awk '{ printf $1 }')
+
+if [ -n $ephemeral_disk ]; then
+  echo "# Setting up disk $ephemeral_disk";
+	/sbin/mkfs.ext4 -q $ephemeral_disk
+	partprobe -s
+	sed -i.bak '/\/opt/d' /etc/fstab
+	echo "$ephemeral_disk /opt/ ext4 defaults 0 0" >> /etc/fstab
+	mount -a
+fi
+
 # dependenciess
 
 apt-get update

--- a/dev_cycle/terraform/install.sh
+++ b/dev_cycle/terraform/install.sh
@@ -5,16 +5,18 @@ set -ex
 # ephemeral disk setup
 
 apt install nvme-cli
-
+user=ubuntu
+ephemeral_dir="/home/$user/project"
 ephemeral_disk=$(nvme list | grep "Instance Storage" | awk '{ printf $1 }')
 
-if [ -n $ephemeral_disk ]; then
+if [ -n "$ephemeral_disk" ]; then
   echo "# Setting up disk $ephemeral_disk";
-	/sbin/mkfs.ext4 -q $ephemeral_disk
-	partprobe -s
-	sed -i.bak '/\/opt/d' /etc/fstab
-	echo "$ephemeral_disk /opt/ ext4 defaults 0 0" >> /etc/fstab
-	mount -a
+  mkdir -p $ephemeral_dir
+  /sbin/mkfs.ext4 -q $ephemeral_disk
+  partprobe -s
+  echo "$ephemeral_disk $ephemeral_dir/ ext4 defaults 0 0" >> /etc/fstab
+  mount -a
+  chown -R $user: $ephemeral_dir && chmod -R 755 $ephemeral_dir
 fi
 
 # dependenciess

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -114,7 +114,7 @@ data "aws_iam_policy_document" "build_machine" {
       "kms:DescribeKey",
     ]
     resources = [
-      "${var.ebs_kms_key_arn}"
+      var.ebs_kms_key_arn
     ]
   }
 

--- a/dev_cycle/terraform/output.tf
+++ b/dev_cycle/terraform/output.tf
@@ -1,0 +1,3 @@
+output "instance_id" {
+  value = local.build_machine.instance_id
+}


### PR DESCRIPTION
add the option to provide the build machine as spot since it saves money and allow the user to launch powerful instances much cheaper than ondemands.
also add ephemeral disk setup just in case of taking advantage of nvme perfomance on \*d\* instance types.