### PR TITLE
feat: subnet_id input

### DIFF
--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -5,6 +5,7 @@ variable "instance_type" {}
 variable "key_pair_name" {}
 variable "machine_name" {}
 variable "vpc_id" {}
+variable "subnet_id" {}
 variable "aws_iam_role_id" {}
 variable "ebs_kms_key_arn" {}
 variable "linuxkit_bucket_name" {}

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -45,7 +45,7 @@ resource "aws_instance" "build_machine" {
   instance_type = var.instance_type
   iam_instance_profile = aws_iam_instance_profile.build_node.id
   key_name = var.key_pair_name
-  subnet_id = data.aws_instance.linuxkit_instance.subnet_id
+  subnet_id = var.subnet_id
   associate_public_ip_address = true
 
   root_block_device {
@@ -69,7 +69,7 @@ resource "aws_spot_instance_request" "build_machine" {
   instance_type = var.instance_type
   iam_instance_profile = aws_iam_instance_profile.build_node.id
   key_name = var.key_pair_name
-  subnet_id = data.aws_instance.linuxkit_instance.subnet_id
+  subnet_id = var.subnet_id
   associate_public_ip_address = true
 
   root_block_device {


### PR DESCRIPTION
we should be able to select the machine subnet since sharing build machine with linuxkit instances is not always the desired scenario 