### PR TITLE
refact: bring aws_iam_role into the module

### DIFF
--- a/dev_cycle/terraform/ec2.tf
+++ b/dev_cycle/terraform/ec2.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "build_machine" {
 
   ami = data.aws_ami.ubuntu.id
   instance_type = var.instance_type
-  iam_instance_profile = aws_iam_instance_profile.build_node.id
+  iam_instance_profile = aws_iam_instance_profile.build_machine.id
   key_name = var.key_pair_name
   subnet_id = var.subnet_id
   associate_public_ip_address = true
@@ -18,7 +18,7 @@ resource "aws_instance" "build_machine" {
     Name = var.machine_name
   }
 
-  vpc_security_group_ids = [aws_security_group.build_node_access.id]
+  vpc_security_group_ids = [aws_security_group.build_machine_access.id]
   user_data_base64 = data.cloudinit_config.install.rendered
 }
 
@@ -28,7 +28,7 @@ resource "aws_spot_instance_request" "build_machine" {
 
   ami = data.aws_ami.ubuntu.id
   instance_type = var.instance_type
-  iam_instance_profile = aws_iam_instance_profile.build_node.id
+  iam_instance_profile = aws_iam_instance_profile.build_machine.id
   key_name = var.key_pair_name
   subnet_id = var.subnet_id
   associate_public_ip_address = true
@@ -42,11 +42,11 @@ resource "aws_spot_instance_request" "build_machine" {
     Name = var.machine_name
   }
 
-  vpc_security_group_ids = [aws_security_group.build_node_access.id]
+  vpc_security_group_ids = [aws_security_group.build_machine_access.id]
   user_data_base64 = data.cloudinit_config.install.rendered
 }
 
-resource "aws_security_group" "build_node_access" {
+resource "aws_security_group" "build_machine_access" {
   name_prefix = var.machine_name
   vpc_id = var.vpc_id
 

--- a/dev_cycle/terraform/iam.tf
+++ b/dev_cycle/terraform/iam.tf
@@ -51,7 +51,7 @@ data "aws_iam_policy_document" "build_machine" {
   depends_on = [data.aws_instance.linuxkit_instance]
 }
 
-resource "aws_iam_instance_profile" "build_node" {
+resource "aws_iam_instance_profile" "build_machine" {
   name_prefix = var.machine_name
   role = var.aws_iam_role_id
 }

--- a/dev_cycle/terraform/iam.tf
+++ b/dev_cycle/terraform/iam.tf
@@ -1,3 +1,23 @@
+resource "aws_iam_role" "build_machine" {
+  name = "build-machine-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
 data "aws_iam_policy_document" "build_machine" {
 
   statement {
@@ -53,7 +73,7 @@ data "aws_iam_policy_document" "build_machine" {
 
 resource "aws_iam_instance_profile" "build_machine" {
   name_prefix = var.machine_name
-  role = var.aws_iam_role_id
+  role = aws_iam_role.build_machine.name
 }
 
 resource "aws_iam_policy" "allow_build_volume_attachment" {
@@ -64,10 +84,11 @@ resource "aws_iam_policy" "allow_build_volume_attachment" {
 
 resource "aws_iam_role_policy_attachment" "allow_build_volume_attachment" {
   policy_arn = aws_iam_policy.allow_build_volume_attachment.arn
-  role = var.aws_iam_role_id
+  role = aws_iam_role.build_machine.name
 }
 
 resource "aws_iam_role_policy_attachment" "vmimport" {
   policy_arn = module.vmimport.iam_policy_arn
-  role = var.aws_iam_role_id
+  role = aws_iam_role.build_machine.name
+
 }

--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -7,7 +7,6 @@ variable "key_pair_name" {}
 variable "machine_name" {}
 variable "vpc_id" {}
 variable "subnet_id" {}
-variable "aws_iam_role_id" {}
 variable "ebs_kms_key_arn" {}
 variable "linuxkit_bucket_name" {}
 

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -37,7 +37,6 @@ data "cloudinit_config" "install" {
   }
 }
 
-
 data "aws_region" "region" {}
 data "aws_caller_identity" "identity" {}
 


### PR DESCRIPTION
* remove `aws_iam_role_id` input
* rename `aws_iam_instance_profile` resource name from `build_node` to `build_machine` since that one it's already used throughout the module

IMHO There is no need to add `aws_iam_role` output, `instance_id` is enough