### PR TITLE
fix: vmimport module

### DIFF
--- a/dev_cycle/terraform/iam.tf
+++ b/dev_cycle/terraform/iam.tf
@@ -89,7 +89,7 @@ data "aws_iam_policy_document" "linuxkit_push" {
       "s3:GetObject"
     ]
     resources = [
-      "arn:aws:s3:::${var.linuxkit_bucket_name}/*"
+      "arn:aws:s3:::${var.bucket_name}/*"
     ]
   }
 

--- a/dev_cycle/terraform/iam.tf
+++ b/dev_cycle/terraform/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "build_machine" {
-  name = "build-machine-role"
+  name = var.machine_name
 
   assume_role_policy = <<EOF
 {

--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -10,6 +10,12 @@ variable "subnet_id" {}
 variable "ebs_kms_key_arn" {}
 variable "linuxkit_bucket_name" {}
 
+variable "vmimport_service_role" {
+  description = "Enable vmimport service role creation"
+  type = bool
+  default = true
+}
+
 variable "install" {
   type = object({
     linuxkit_version = string

--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -10,7 +10,7 @@ variable "subnet_id" {}
 variable "ebs_kms_key_arn" {}
 variable "bucket_name" {}
 
-variable "vmimport_role_enabled" {
+variable "vmimport_service_role_enabled" {
   description = "Enable vmimport service role creation"
   type = bool
   default = true

--- a/dev_cycle/terraform/input.tf
+++ b/dev_cycle/terraform/input.tf
@@ -8,9 +8,9 @@ variable "machine_name" {}
 variable "vpc_id" {}
 variable "subnet_id" {}
 variable "ebs_kms_key_arn" {}
-variable "linuxkit_bucket_name" {}
+variable "bucket_name" {}
 
-variable "vmimport_service_role" {
+variable "vmimport_role_enabled" {
   description = "Enable vmimport service role creation"
   type = bool
   default = true

--- a/dev_cycle/terraform/install.sh
+++ b/dev_cycle/terraform/install.sh
@@ -4,7 +4,7 @@ set -ex
 
 # export linuxkit bucket name as environment variable
 
-echo export LINUXKIT_BUCKET="${linuxkit_bucket_name}" >> /etc/profile
+echo export LINUXKIT_BUCKET="${bucket_name}" >> /etc/profile
 
 # ephemeral disk setup
 

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -43,5 +43,5 @@ data "aws_caller_identity" "identity" {}
 module "vmimport" {
   source = "../../vmimport/terraform"
   bucket_name = var.bucket_name
-  vmimport_role_enabled = var.vmimport_role_enabled
+  service_role_enabled = var.vmimport_service_role_enabled
 }

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -43,4 +43,5 @@ data "aws_caller_identity" "identity" {}
 module "vmimport" {
   source = "../../vmimport/terraform"
   linuxkit_bucket_name = var.linuxkit_bucket_name
+  vmimport_service_role = var.vmimport_service_role
 }

--- a/dev_cycle/terraform/main.tf
+++ b/dev_cycle/terraform/main.tf
@@ -32,7 +32,7 @@ provider "cloudinit" {
 data "cloudinit_config" "install" {
   part {
     content_type = "text/x-shellscript"
-    content = templatefile("${path.module}/install.sh",merge(var.install,{linuxkit_bucket_name=var.linuxkit_bucket_name}))
+    content = templatefile("${path.module}/install.sh",merge(var.install,{bucket_name=var.bucket_name}))
     filename = "install.sh"
   }
 }
@@ -42,6 +42,6 @@ data "aws_caller_identity" "identity" {}
 
 module "vmimport" {
   source = "../../vmimport/terraform"
-  linuxkit_bucket_name = var.linuxkit_bucket_name
-  vmimport_service_role = var.vmimport_service_role
+  bucket_name = var.bucket_name
+  vmimport_role_enabled = var.vmimport_role_enabled
 }

--- a/vmimport/terraform/input.tf
+++ b/vmimport/terraform/input.tf
@@ -1,9 +1,15 @@
-variable "linuxkit_bucket_name" {
+variable "bucket_name" {
   description = "S3 bucket name for storing the exported linuxkit images"
   type        = string
 }
 
-variable "vmimport_service_role" {
+variable "bucket_enabled" {
+  description = "Enable S3 bucket creation"
+  type = bool
+  default = true
+}
+
+variable "service_role_enabled" {
   description = "Enable vmimport service role creation"
   type = bool
   default = true

--- a/vmimport/terraform/input.tf
+++ b/vmimport/terraform/input.tf
@@ -2,3 +2,9 @@ variable "linuxkit_bucket_name" {
   description = "S3 bucket name for storing the exported linuxkit images"
   type        = string
 }
+
+variable "vmimport_service_role" {
+  description = "Enable vmimport service role creation"
+  type = bool
+  default = true
+}

--- a/vmimport/terraform/main.tf
+++ b/vmimport/terraform/main.tf
@@ -14,6 +14,7 @@ resource "aws_s3_bucket_public_access_block" "vmimport" {
 }
 
 data "aws_iam_policy_document" "vmimport" {
+  count = var.vmimport_service_role ? 1 : 0
   statement {
     actions = ["sts:AssumeRole"]
     effect  = "Allow"
@@ -30,11 +31,13 @@ data "aws_iam_policy_document" "vmimport" {
 }
 
 resource "aws_iam_role" "vmimport" {
+  count = var.vmimport_service_role ? 1 : 0
   name               = "vmimport"
-  assume_role_policy = data.aws_iam_policy_document.vmimport.json
+  assume_role_policy = data.aws_iam_policy_document.vmimport.0.json
 }
 
 data "aws_iam_policy_document" "vmimport_access" {
+  count = var.vmimport_service_role ? 1 : 0
   statement {
     actions = [
       "s3:GetBucketLocation",
@@ -60,11 +63,13 @@ data "aws_iam_policy_document" "vmimport_access" {
 }
 
 resource "aws_iam_policy" "vmimport_access" {
+  count = var.vmimport_service_role ? 1 : 0
   name   = "VMImportAccess"
-  policy = data.aws_iam_policy_document.vmimport_access.json
+  policy = data.aws_iam_policy_document.vmimport_access.0.json
 }
 
 resource "aws_iam_role_policy_attachment" "vmimport_access" {
-  role       = aws_iam_role.vmimport.name
-  policy_arn = aws_iam_policy.vmimport_access.arn
+  count = var.vmimport_service_role ? 1 : 0
+  role       = aws_iam_role.vmimport.0.name
+  policy_arn = aws_iam_policy.vmimport_access.0.arn
 }

--- a/vmimport/terraform/main.tf
+++ b/vmimport/terraform/main.tf
@@ -18,27 +18,20 @@ data "aws_iam_policy_document" "vmimport" {
   statement {
     effect = "Allow"
     actions = [
-      "s3:GetBucketLocation",
-      "s3:GetObject",
-      "s3:ListBucket",
-      "s3:PutObject",
-      "s3:GetBucketAcl"
+      "s3:GetObject*",
+      "s3:PutObject*"
     ]
     resources = [
-      "arn:aws:s3:::${var.linuxkit_bucket_name}",
       "arn:aws:s3:::${var.linuxkit_bucket_name}/*"
-
     ]
   }
 
   statement {
     effect = "Allow"
     actions = [
-      "ec2:ModifySnapshotAttribute",
-      "ec2:CopySnapshot",
-      "ec2:DescribeImportSnapshotTasks",
       "ec2:RegisterImage",
-      "ec2:Describe*",
+      "ec2:ImportSnapshot",
+      "ec2:DescribeImportSnapshotTasks"
     ]
     resources = [
       "*"

--- a/vmimport/terraform/main.tf
+++ b/vmimport/terraform/main.tf
@@ -1,12 +1,15 @@
 resource "aws_s3_bucket" "vmimport" {
-  bucket = var.linuxkit_bucket_name
+  count = var.bucket_enabled ? 1 : 0
+
+  bucket = var.bucket_name
   acl    = "private"
   force_destroy = true
 }
 
 resource "aws_s3_bucket_public_access_block" "vmimport" {
-  bucket = aws_s3_bucket.vmimport.id
+  count = var.bucket_enabled ? 1 : 0
 
+  bucket = aws_s3_bucket.vmimport.0.id
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
@@ -14,7 +17,7 @@ resource "aws_s3_bucket_public_access_block" "vmimport" {
 }
 
 data "aws_iam_policy_document" "vmimport" {
-  count = var.vmimport_service_role ? 1 : 0
+  count = var.service_role_enabled ? 1 : 0
   statement {
     actions = ["sts:AssumeRole"]
     effect  = "Allow"
@@ -31,13 +34,13 @@ data "aws_iam_policy_document" "vmimport" {
 }
 
 resource "aws_iam_role" "vmimport" {
-  count = var.vmimport_service_role ? 1 : 0
+  count = var.service_role_enabled ? 1 : 0
   name               = "vmimport"
   assume_role_policy = data.aws_iam_policy_document.vmimport.0.json
 }
 
 data "aws_iam_policy_document" "vmimport_access" {
-  count = var.vmimport_service_role ? 1 : 0
+  count = var.service_role_enabled ? 1 : 0
   statement {
     actions = [
       "s3:GetBucketLocation",
@@ -46,8 +49,8 @@ data "aws_iam_policy_document" "vmimport_access" {
     ]
     effect = "Allow"
     resources = [
-      "arn:aws:s3:::${var.linuxkit_bucket_name}",
-      "arn:aws:s3:::${var.linuxkit_bucket_name}/*"
+      "arn:aws:s3:::${var.bucket_name}",
+      "arn:aws:s3:::${var.bucket_name}/*"
     ]
   }
   statement {
@@ -63,13 +66,13 @@ data "aws_iam_policy_document" "vmimport_access" {
 }
 
 resource "aws_iam_policy" "vmimport_access" {
-  count = var.vmimport_service_role ? 1 : 0
+  count = var.service_role_enabled ? 1 : 0
   name   = "VMImportAccess"
   policy = data.aws_iam_policy_document.vmimport_access.0.json
 }
 
 resource "aws_iam_role_policy_attachment" "vmimport_access" {
-  count = var.vmimport_service_role ? 1 : 0
+  count = var.service_role_enabled ? 1 : 0
   role       = aws_iam_role.vmimport.0.name
   policy_arn = aws_iam_policy.vmimport_access.0.arn
 }

--- a/vmimport/terraform/output.tf
+++ b/vmimport/terraform/output.tf
@@ -1,3 +1,3 @@
-output "iam_policy_arn" {
-  value = aws_iam_policy.vmimport.arn
+output "iam_role_arn" {
+  value = var.vmimport_service_role == "false" ? aws_iam_role.vmimport.0.arn : null
 }

--- a/vmimport/terraform/output.tf
+++ b/vmimport/terraform/output.tf
@@ -1,3 +1,3 @@
 output "iam_role_arn" {
-  value = var.vmimport_service_role == "false" ? aws_iam_role.vmimport.0.arn : null
+  value = var.service_role_enabled == "false" ? aws_iam_role.vmimport.0.arn : null
 }


### PR DESCRIPTION
basically vmimport service role must be a unique resource that allow us to import raw images from S3 to EC2 (AMI/Snapshots). So I added two uses of vmimport module: simply provide a S3 bucket and/or create the vmimport service role

In summary:
* vmimport aims to create the S3 bucket and service role required to perform an image import
* dev_cycle aims to prepare the development environment and ensures the right permissions to the build machine perform it
