### PR TITLE
fix babashka download url

### DIFF
--- a/dev_cycle/terraform/install.sh
+++ b/dev_cycle/terraform/install.sh
@@ -60,7 +60,7 @@ chmod +x /usr/local/bin/linuxkit
 
 # install babashka
 
-curl -s https://raw.githubusercontent.com/borkdude/babashka/${babashka_version}/install -o install-babashka
+curl -s https://raw.githubusercontent.com/babashka/babashka/${babashka_version}/install -o install-babashka
 chmod +x install-babashka
 ./install-babashka
 


### PR DESCRIPTION
`borkdude/babashka` repo was changed to `babashka/babashka`, the old URL still works; I'm not sure for how long though.